### PR TITLE
♻️️ change scheduling logic to use UTC 

### DIFF
--- a/src/models/Message.js
+++ b/src/models/Message.js
@@ -47,17 +47,8 @@ messageSchema.methods.reschedule = async function (newTime) {
 	return this;
 };
 
-messageSchema.methods.getFormattedScheduledFor = function (locale = 'en-US', timezone = 'UTC') {
-	return this.scheduledFor.toLocaleString(locale, {
-		timeZone: timezone,
-		weekday: 'long',
-		year: 'numeric',
-		month: 'long',
-		day: 'numeric',
-		hour: '2-digit',
-		minute: '2-digit',
-		timeZoneName: 'short',
-	});
+messageSchema.methods.getFormattedScheduledFor = function () {
+	return this.scheduledFor.toISOString();
 };
 
 messageSchema.statics.findPending = function () {

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -5,18 +5,17 @@ import logger from '@utils/logger.js';
 
 const checkScheduledMessages = async () => {
 	try {
-		const now = new Date();
+		const nowUTC = new Date();
 		const messages = await Message.find({
-			scheduledFor: { $lte: now },
+			scheduledFor: { $lte: nowUTC },
 			sent: false,
 		});
 
 		for (const message of messages) {
 			try {
 				await discordService.sendMessage(message.channelId, message.content);
-				message.sent = true;
-				await message.save();
-				logger.info(`Sent scheduled message: ${message._id}`);
+				await message.markAsSent();
+				logger.info(`Sent scheduled message: ${message._id} at ${nowUTC.toISOString()}`);
 			} catch (error) {
 				logger.error(`Failed to send message ${message._id}: ${error.message}`);
 			}


### PR DESCRIPTION
# Timezone Handling for Scheduled Messages

## Description
Improved message scheduling by ensuring consistent UTC timestamp handling between local and server environments. This change helps prevent timezone-related scheduling issues when creating messages from different locations.

## Changes Made
- Modified [`createMessage`](src/controllers/messageController.js) to properly handle UTC timestamps
- Added timezone validation and conversion logic
- Fixed issue where messages were being sent immediately due to incorrect timezone comparison

## Example Request
```json
{
  "content": "@everyone ¡Hola! Este es un mensaje programado",
  "scheduledFor": "2025-02-14T14:25:00Z",  // Now using UTC format with Z suffix
  "channelId": "948395736440111137"
}